### PR TITLE
Make BUILD_EXAMPLES and BUILD_TESTS submodule-friendly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,15 @@ project(kappa-core
 # ========================================
 # Build Options
 # ========================================
-option(BUILD_EXAMPLES "Build example applications" ON)
-option(BUILD_TESTS "Build test executables" ON)
+# Only build examples and tests by default when this is the main project
+# When used as a submodule, these should be OFF by default to avoid cluttering parent builds
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    option(BUILD_EXAMPLES "Build example applications" ON)
+    option(BUILD_TESTS "Build test executables" ON)
+else()
+    option(BUILD_EXAMPLES "Build example applications" OFF)
+    option(BUILD_TESTS "Build test executables" OFF)
+endif()
 option(ENABLE_COVERAGE "Enable code coverage analysis" OFF)
 
 # ========================================


### PR DESCRIPTION
Fixes #9

## Changes

Automatically disable examples and tests when kappa-core is used as a submodule, following the standard CMake pattern.

**Behavior:**
- **Standalone build**: Examples and tests ON by default (for development)
- **Submodule build**: Examples and tests OFF by default (clean parent builds)
- **Override**: Users can still force with `-DBUILD_EXAMPLES=ON` if needed

## Benefits

- Faster builds for downstream projects (no unnecessary targets)
- Cleaner build output
- Standard CMake best practice (matches spdlog, fmt, nlohmann_json)
- No breaking changes

## Testing

Tested both scenarios:
- Standalone: `cmake -B build` → examples and tests build ✓
- Submodule: Used in vision-craft → examples and tests skipped ✓